### PR TITLE
Fix failing tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^uuid$': '<rootDir>/node_modules/uuid/dist/index.js',
+  },
+  setupFiles: ['./jest.setup.ts'],
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,19 @@
+if (typeof (globalThis as any).global === 'undefined') {
+  (globalThis as any).global = globalThis;
+}
+
+if (typeof (global as any).localStorage === 'undefined') {
+  let store: Record<string, string> = {};
+  (global as any).localStorage = {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as any;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,11 +9,15 @@ interface Project {
 }
 
 const loadProjects = (): Project[] => {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
   const data = localStorage.getItem('projects');
   return data ? JSON.parse(data) : [];
 };
 
 const saveProjects = (projects: Project[]) => {
+  if (typeof localStorage === 'undefined') return;
   localStorage.setItem('projects', JSON.stringify(projects));
 };
 

--- a/src/__tests__/addProject.steps.tsx
+++ b/src/__tests__/addProject.steps.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { loadFeature, defineFeature } from 'jest-cucumber';
+import path from 'path';
 import App from '../App';
 
-const feature = loadFeature('../../features/addProject.feature');
+const feature = loadFeature(path.join(__dirname, '../../features/addProject.feature'));
 
 defineFeature(feature, test => {
   test('add a project to the list', ({ given, when, then, and }) => {


### PR DESCRIPTION
## Summary
- ensure Jest can run under Node 22
- patch App to handle missing localStorage
- use uuid's CommonJS build in Jest
- fix feature path and rename test file to `.tsx`
- add localStorage polyfill for tests

## Testing
- `npm test`
