### PR TITLE
Add stop timer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ A simple time tracking web application built with React and TypeScript.
    ```
 
 The application stores data in your browser `localStorage`.
+Click "Start" next to a project to begin tracking time. When a project is running a "Stop" button lets you end the timer.

--- a/features/stopTimer.feature
+++ b/features/stopTimer.feature
@@ -1,0 +1,13 @@
+Feature: Stop a timer
+  As a user
+  I want to stop tracking time for a project
+  So that I can pause work on it
+
+  Scenario: start and stop a timer
+    Given the app is mounted
+    When the user types "My Project" into the project name input
+    And the user clicks "Add Project"
+    And the user clicks "Start"
+    Then the button for the project should display "Stop"
+    And the user clicks "Stop"
+    Then the button for the project should display "Start"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,14 +38,15 @@ export default function App() {
     setName('');
   };
 
-  const startTimer = (id: number) => {
+  const toggleTimer = (id: number) => {
     setProjects(prev =>
       prev.map(p => {
         if (p.id === id) {
-          if (!p.isRunning) {
-            return { ...p, isRunning: true, startTime: Date.now() };
+          if (p.isRunning && p.startTime) {
+            const elapsed = Date.now() - p.startTime;
+            return { ...p, isRunning: false, totalTime: p.totalTime + elapsed, startTime: undefined };
           }
-          return p;
+          return { ...p, isRunning: true, startTime: Date.now() };
         }
         if (p.isRunning && p.startTime) {
           const elapsed = Date.now() - p.startTime;
@@ -86,8 +87,8 @@ export default function App() {
             <li key={p.id}>
               <span>{p.name}</span>
               <span> {formatTime(p.totalTime + runningTime)}</span>
-              <button onClick={() => startTimer(p.id)}>
-                {p.isRunning ? 'Running' : 'Start'}
+              <button onClick={() => toggleTimer(p.id)}>
+                {p.isRunning ? 'Stop' : 'Start'}
               </button>
             </li>
           );

--- a/src/__tests__/stopTimer.steps.tsx
+++ b/src/__tests__/stopTimer.steps.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { loadFeature, defineFeature } from 'jest-cucumber';
+import path from 'path';
+import App from '../App';
+
+const feature = loadFeature(path.join(__dirname, '../../features/stopTimer.feature'));
+
+defineFeature(feature, test => {
+  test('start and stop a timer', ({ given, when, then, and }) => {
+    given('the app is mounted', () => {
+      render(<App />);
+    });
+
+    when(/^the user types "([^"]*)" into the project name input$/, name => {
+      fireEvent.change(screen.getByPlaceholderText('Project name'), {
+        target: { value: name },
+      });
+    });
+
+    and('the user clicks "Add Project"', () => {
+      fireEvent.click(screen.getByText('Add Project'));
+    });
+
+    and('the user clicks "Start"', () => {
+      fireEvent.click(screen.getByText('Start'));
+    });
+
+    then('the button for the project should display "Stop"', () => {
+      expect(screen.getByText('Stop')).toBeInTheDocument();
+    });
+
+    and('the user clicks "Stop"', () => {
+      fireEvent.click(screen.getByText('Stop'));
+    });
+
+    then('the button for the project should display "Start"', () => {
+      expect(screen.getByText('Start')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow toggling timers so running projects can be stopped
- show `Stop` button when a project is running
- document start/stop usage
- add BDD test for stopping a timer

## Testing
- `npm test`