### PR TITLE
Implement custom dialog modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ under the project name.
 
 The interface now features a styled layout with clearly separated components for
 adding projects and viewing the list.
+
+Prompt and confirmation dialogs now appear as in-app modals instead of relying on browser alerts.

--- a/src/App.css
+++ b/src/App.css
@@ -57,3 +57,26 @@ h1 {
 .project-item button {
   padding: 4px 12px;
 }
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.modal button {
+  margin-right: 8px;
+}

--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { setDialogImpl } from '../utils/dialog';
+
+interface ConfirmState {
+  type: 'confirm';
+  message: string;
+  resolve: (value: boolean) => void;
+}
+
+interface PromptState {
+  type: 'prompt';
+  message: string;
+  resolve: (value: string | null) => void;
+}
+
+type DialogState = ConfirmState | PromptState | null;
+
+export const DialogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, setState] = useState<DialogState>(null);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    setDialogImpl({
+      confirm: (msg: string) =>
+        new Promise<boolean>(resolve => setState({ type: 'confirm', message: msg, resolve })),
+      prompt: (msg: string) =>
+        new Promise<string | null>(resolve => {
+          setInput('');
+          setState({ type: 'prompt', message: msg, resolve });
+        }),
+    });
+  }, []);
+
+  const handleConfirm = (value: boolean) => {
+    if (state && state.type === 'confirm') {
+      state.resolve(value);
+      setState(null);
+    }
+  };
+
+  const handlePrompt = (value: string | null) => {
+    if (state && state.type === 'prompt') {
+      state.resolve(value);
+      setState(null);
+    }
+  };
+
+  return (
+    <>
+      {children}
+      {state && state.type === 'confirm' && (
+        <div className="modal-overlay">
+          <div className="modal">
+            <p>{state.message}</p>
+            <button onClick={() => handleConfirm(true)}>OK</button>
+            <button onClick={() => handleConfirm(false)}>Cancel</button>
+          </div>
+        </div>
+      )}
+      {state && state.type === 'prompt' && (
+        <div className="modal-overlay">
+          <div className="modal">
+            <p>{state.message}</p>
+            <input value={input} onChange={e => setInput(e.target.value)} />
+            <button onClick={() => handlePrompt(input)}>OK</button>
+            <button onClick={() => handlePrompt(null)}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { DialogProvider } from './components/DialogProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <DialogProvider>
+      <App />
+    </DialogProvider>
   </React.StrictMode>
 );

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -1,0 +1,21 @@
+export type Dialog = {
+  confirm: (message: string) => Promise<boolean>;
+  prompt: (message: string) => Promise<string | null>;
+};
+
+let impl: Dialog = {
+  confirm: async (msg: string) => Promise.resolve(window.confirm(msg)),
+  prompt: async (msg: string) => Promise.resolve(window.prompt(msg)),
+};
+
+export function setDialogImpl(dialog: Dialog) {
+  impl = dialog;
+}
+
+export function confirm(message: string): Promise<boolean> {
+  return impl.confirm(message);
+}
+
+export function prompt(message: string): Promise<string | null> {
+  return impl.prompt(message);
+}


### PR DESCRIPTION
## Summary
- add DialogProvider with modal UI
- use dialog helpers in App
- wrap App with provider
- style modal overlay
- update tests for new dialog API
- document dialog behavior

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script)*