### PR TITLE
Add card layout for projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,6 @@ under the project name.
 The interface now features a styled layout with clearly separated components for
 adding projects and viewing the list.
 
+Projects are displayed as cards with their details neatly aligned for improved readability.
+
 Prompt and confirmation dialogs now appear as in-app modals instead of relying on browser alerts.

--- a/src/App.css
+++ b/src/App.css
@@ -43,19 +43,36 @@ h1 {
 }
 
 .project-item {
+  background: #fafafa;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 12px;
+  list-style: none;
+}
+
+.project-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 0;
-  border-bottom: 1px solid #eee;
+  gap: 8px;
 }
 
-.project-item:last-child {
-  border-bottom: none;
+.project-info {
+  display: flex;
+  justify-content: space-between;
+  flex: 1;
+  gap: 16px;
 }
 
 .project-item button {
   padding: 4px 12px;
+}
+
+.activity-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 8px 0 0;
 }
 
 .modal-overlay {

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -28,14 +28,16 @@ export default function ProjectItem({ project, now, formatTime, onToggle }: Prop
   }, {});
   return (
     <li className="project-item">
-      <div>
-        <span>{project.name}</span>
-        <span>{formatTime(runningTime)}</span>
+      <div className="project-header">
+        <div className="project-info">
+          <span className="project-name">{project.name}</span>
+          <span className="project-time">{formatTime(runningTime)}</span>
+        </div>
+        <button onClick={() => onToggle(project.id)}>
+          {project.isRunning ? 'Stop' : 'Start'}
+        </button>
       </div>
-      <button onClick={() => onToggle(project.id)}>
-        {project.isRunning ? 'Stop' : 'Start'}
-      </button>
-      <ul>
+      <ul className="activity-list">
         {Object.entries(totals).map(([desc, time]) => (
           <li key={desc}>{`${desc} - ${formatTime(time)}`}</li>
         ))}


### PR DESCRIPTION
## Summary
- style each project item as a card
- align project details within a new header section
- document card layout in README

## Testing
- `npm test`